### PR TITLE
Patch mouse movement not registering before adding the first minigame

### DIFF
--- a/src/main/java/com/runeliteminigame/display/MinigameDisplayContainer.java
+++ b/src/main/java/com/runeliteminigame/display/MinigameDisplayContainer.java
@@ -414,10 +414,16 @@ public class MinigameDisplayContainer extends Overlay implements IMinigameInputH
             struct.handler = this.minigameToolbar;
             struct.offset = relativeOffset;
         }
-        else if (this.loadedMinigames.size() > 0)
-        {
-            struct.handler = this.loadedMinigames.get(this.currentMinigameIndex);
-            struct.offset = new Point(relativeOffset.x, relativeOffset.y - MinigameToolbar.getToolbarHeight());
+        else {
+            // Inside of the minigame box.
+            if (this.loadedMinigames.size() > 0)
+            {
+                struct.handler = this.loadedMinigames.get(this.currentMinigameIndex);
+                struct.offset = new Point(relativeOffset.x, relativeOffset.y - MinigameToolbar.getToolbarHeight());
+            }
+            else {
+                struct.offset = new Point(relativeOffset.x, relativeOffset.y - MinigameToolbar.getToolbarHeight());
+            }
         }
         return struct;
     }


### PR DESCRIPTION
Patches mouse movement not registering before adding the first minigame when moving into the minigame sub-box.

Root cause was that when there are no minigames, the relative component struct did not have a valid offset provided. Therefore, the previous point had no offset over which to calculate, so the mouse movement was not registered.

Closes #27 