### PR TITLE
Patch click and drag bugs; stop capturing mouse wheel events

### DIFF
--- a/src/main/java/com/runelitebingo/RuneliteBingoPlugin.java
+++ b/src/main/java/com/runelitebingo/RuneliteBingoPlugin.java
@@ -148,7 +148,7 @@ public class RuneliteBingoPlugin extends Plugin implements IMinigamePlugin
 		{
 			this.playerDamageDealt.clear();
 		}
-		bingoOverlay.onGameStateChanged(event);
+		bingoOverlay.onGameStateChanged();
 	}
 
 	@Subscribe

--- a/src/main/java/com/runelitebingo/SinglePlayerBingoGame.java
+++ b/src/main/java/com/runelitebingo/SinglePlayerBingoGame.java
@@ -267,6 +267,11 @@ public class SinglePlayerBingoGame implements IDisplayableMinigame {
     }
 
     @Override
+    public MouseEvent mouseDragged(MouseEvent event, Point relativeOffset) {
+        return this.mouseMoved(event, relativeOffset);
+    }
+
+    @Override
     public RelativeMinigameComponentStruct getSubComponentAtPoint(Point relativeOffset) {
         return new RelativeMinigameComponentStruct();
     }

--- a/src/main/java/com/runeliteminigame/display/BaseMinigameDirectionalButton.java
+++ b/src/main/java/com/runeliteminigame/display/BaseMinigameDirectionalButton.java
@@ -54,6 +54,11 @@ public abstract class BaseMinigameDirectionalButton implements IDisplayableWithI
     }
 
     @Override
+    public MouseEvent mouseDragged(MouseEvent event, Point relativeOffset) {
+        return this.mouseMoved(event, relativeOffset);
+    }
+
+    @Override
     public RelativeMinigameComponentStruct getSubComponentAtPoint(Point relativeOffset) {
         return new RelativeMinigameComponentStruct();
     }

--- a/src/main/java/com/runeliteminigame/display/IMinigameInputHandler.java
+++ b/src/main/java/com/runeliteminigame/display/IMinigameInputHandler.java
@@ -21,6 +21,8 @@ interface IMinigameInputHandler {
 
     MouseEvent mouseMoved(MouseEvent event, Point relativeOffset);
 
+    MouseEvent mouseDragged(MouseEvent event, Point relativeOffset);
+
     RelativeMinigameComponentStruct getSubComponentAtPoint(Point relativeOffset);
 }
 

--- a/src/main/java/com/runeliteminigame/display/MinigameAddButton.java
+++ b/src/main/java/com/runeliteminigame/display/MinigameAddButton.java
@@ -63,6 +63,11 @@ public class MinigameAddButton implements IDisplayableWithIcon, IMinigameInputHa
     }
 
     @Override
+    public MouseEvent mouseDragged(MouseEvent event, Point relativeOffset) {
+        return this.mouseMoved(event, relativeOffset);
+    }
+
+    @Override
     public RelativeMinigameComponentStruct getSubComponentAtPoint(Point relativeOffset) {
         return new RelativeMinigameComponentStruct();
     }

--- a/src/main/java/com/runeliteminigame/display/MinigameCloseButton.java
+++ b/src/main/java/com/runeliteminigame/display/MinigameCloseButton.java
@@ -75,6 +75,11 @@ class MinigameCloseButton implements IDisplayableWithIcon, IMinigameInputHandler
     }
 
     @Override
+    public MouseEvent mouseDragged(MouseEvent event, Point relativeOffset) {
+        return this.mouseMoved(event, relativeOffset);
+    }
+
+    @Override
     public RelativeMinigameComponentStruct getSubComponentAtPoint(Point relativeOffset) {
         return new RelativeMinigameComponentStruct();
     }

--- a/src/main/java/com/runeliteminigame/display/MinigameInputListener.java
+++ b/src/main/java/com/runeliteminigame/display/MinigameInputListener.java
@@ -33,6 +33,11 @@ class MinigameInputListener extends MouseAdapter implements KeyListener, MouseWh
     }
 
     @Override
+    public MouseEvent mouseDragged(MouseEvent event) {
+        return minigameDisplayContainer.mouseDragged(event, null);
+    }
+
+    @Override
     public MouseWheelEvent mouseWheelMoved(MouseWheelEvent event) {
         return minigameDisplayContainer.mouseWheelMoved(event, null);
     }

--- a/src/main/java/com/runeliteminigame/display/MinigameSettingsButton.java
+++ b/src/main/java/com/runeliteminigame/display/MinigameSettingsButton.java
@@ -74,6 +74,11 @@ public class MinigameSettingsButton implements IDisplayableWithIcon, IMinigameIn
     }
 
     @Override
+    public MouseEvent mouseDragged(MouseEvent event, Point relativeOffset) {
+        return this.mouseMoved(event, relativeOffset);
+    }
+
+    @Override
     public RelativeMinigameComponentStruct getSubComponentAtPoint(Point relativeOffset) {
         return new RelativeMinigameComponentStruct();
     }

--- a/src/main/java/com/runeliteminigame/display/MinigameToolbar.java
+++ b/src/main/java/com/runeliteminigame/display/MinigameToolbar.java
@@ -238,6 +238,12 @@ public class MinigameToolbar implements IMinigameInputHandler {
     }
 
     @Override
+    public MouseEvent mouseDragged(MouseEvent event, Point relativeOffset) {
+        // TODO: In the future, we may want to consider re-ordering elements with click and drag.
+        return this.mouseMoved(event, relativeOffset);
+    }
+
+    @Override
     public RelativeMinigameComponentStruct getSubComponentAtPoint(Point relativeOffset) {
         RelativeMinigameComponentStruct result = new RelativeMinigameComponentStruct();
         int index = relativeOffset.x / TOOLBAR_HEIGHT;


### PR DESCRIPTION
Patch click and drag bugs; stop capturing mouse wheel events. Resolves #25.

Middle mouse is no longer captured at all so that the underlying UI can still receive camera movement information and controls.